### PR TITLE
removes incoming webhoks register method. closes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Config options are:
   - `logLevel` (String, optional) The log level to use. One of error, warn, info, verbose, debug, silly. Defaults to info.
 
 
+---
+
+
 ### `instance`
 
 The configured instance of the Slack Mock `slackMock.instance` object. This is the same object returned from `slackMock(config)` 
@@ -37,12 +40,12 @@ This includes both responses to the original Events API request and requests to 
   - `statusCode` The status code of the intercepted request
 
 
+---
+
+
 ### `instance.incomingWebhooks` (Incoming Webhooks)
 
-The `incomingWebhooks` object mocks sending payloads from you Slack App to Incoming Webhooks.
-
-- `register`: `function(url)` Registers a Slack Incoming Webhook endpoint your Slack app will POST to.
-Incoming webhook urls should be registered **before** they are used.
+The `incomingWebhooks` object mocks sending payloads from you Slack App to all Incoming Webhooks at `https://hooks.slack.com/`.
 
 - `addResponse`: `function(opts)` Queues a response payload that Slack Mock will use to respond upon
 receiving a post to a registered endpoint. This method can be called multiple times. Responses
@@ -60,6 +63,9 @@ will be used in a FIFO order. Options are:
   - `headers` The headers of the intercepted request as an Object
   - `statusCode` The status code of the intercepted request. Only captured for immediate responses, not for using the `response_url`.
   - `type` Either `response` or `response_url`. Indicates how the call was intercepted.
+
+
+---
 
 
 ### `instance.interactiveButtons` (Interactive Buttons)
@@ -106,6 +112,8 @@ The body will include a `response_url` parameter Returns an immediately resolved
   - `statusCode` The status code of the intercepted request.
 
 
+---
+
 
 ### `instance.rtm` (RTM)
 
@@ -125,6 +133,9 @@ Returns an immediately resolved Promise for easy chaining.
   - `message` The message that was received by the RTM API as an Object.
   - `client` A reference to the websocket client that received the payload.
   - `rawMessage` The original String message received by the RTM API. Good for troubleshooting.
+
+
+---
 
 
 ### `instance.slashCommands` (Slash Commands)
@@ -153,6 +164,9 @@ This includes both responses to the original Slash Command request and requests 
   - `type` Either `response` or `response_url`. Indicates how the call was intercepted.
 
 
+---
+
+
 ### `instance.web` (Web API)
 
 The `web` object receives requests to the Slack Web API and responds with mocked responses.
@@ -175,6 +189,9 @@ Each call will contain
   - `url` The url of the call that was intercepted
   - `params` The POST body merged with any query string parameters captured from the intercepted request as an Object
   - `headers` The headers of the intercepted request as an Object
+
+
+---
 
 
 ### `instance.reset`: `function()`

--- a/index.js
+++ b/index.js
@@ -34,7 +34,6 @@ module.exports = function (config) {
     },
     incomingWebhooks: {
       addResponse: incomingWebhooks.addResponse,
-      register: incomingWebhooks.register,
       reset: incomingWebhooks.reset,
       calls: incomingWebhooks.calls
     },

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -33,7 +33,6 @@ describe('slack-mock', function () {
 
     incomingWebhooksMock = {
       addResponse: sinon.stub(),
-      register: sinon.stub(),
       reset: sinon.stub(),
       calls: []
     }
@@ -129,9 +128,8 @@ describe('slack-mock', function () {
     })
 
     it('should expose incoming webhooks api', function () {
-      expect(instance.incomingWebhooks).to.have.keys(['addResponse', 'register', 'reset', 'calls'])
+      expect(instance.incomingWebhooks).to.have.keys(['addResponse', 'reset', 'calls'])
       expect(instance.incomingWebhooks.addResponse, 'addResponse').to.equal(incomingWebhooksMock.addResponse)
-      expect(instance.incomingWebhooks.register, 'register').to.equal(incomingWebhooksMock.register)
       expect(instance.incomingWebhooks.reset, 'reset').to.equal(incomingWebhooksMock.reset)
       expect(instance.incomingWebhooks.calls, 'calls').to.equal(incomingWebhooksMock.calls)
     })

--- a/test/mocker/incoming-webhooks.spec.js
+++ b/test/mocker/incoming-webhooks.spec.js
@@ -65,38 +65,11 @@ describe('mocker: incoming webhooks', function () {
     }, cb)
   }
 
-  describe('register', function () {
-    let url
-
-    beforeEach(function () {
-      url = 'http://register.not.real'
-    })
-
-    it('should register a url', function (done) {
-      sendToUrl(url, {}, beforeRegister)
-
-      function beforeRegister (err) {
-        expect(err).to.exist
-
-        incomingWebhooks.register(url)
-        sendToUrl(url, {}, afterRegister)
-      }
-
-      function afterRegister (err) {
-        expect(err).not.to.exist
-
-        expect(customResponsesMock.get).to.have.been.calledWith('incoming-webhooks', url)
-        done()
-      }
-    })
-  })
-
   describe('addResponse', function () {
     let url
 
     beforeEach(function () {
-      url = 'http://addResponse.not.real'
-      incomingWebhooks.register(url)
+      url = 'https://hooks.slack.com/addResponse'
     })
 
     it('should add a custom response', function () {
@@ -117,8 +90,7 @@ describe('mocker: incoming webhooks', function () {
     let url
 
     beforeEach(function () {
-      url = 'http://calls.not.real'
-      incomingWebhooks.register(url)
+      url = 'https://hooks.slack.com/calls'
     })
 
     it('should record calls', function (done) {
@@ -127,7 +99,7 @@ describe('mocker: incoming webhooks', function () {
       }
 
       sendToUrl(url, body, () => {
-        expect(utilsMock.parseParams).to.have.been.calledWith('/', {walter: 'white'})
+        expect(utilsMock.parseParams).to.have.been.calledWith('/calls', {walter: 'white'})
         expect(incomingWebhooks.calls).to.have.length(1)
 
         const firstCall = incomingWebhooks.calls[0]
@@ -150,7 +122,7 @@ describe('mocker: incoming webhooks', function () {
         uri: url,
         form: formBody
       }, () => {
-        expect(utilsMock.parseParams).to.have.been.calledWith('/', 'walter=white')
+        expect(utilsMock.parseParams).to.have.been.calledWith('/calls', 'walter=white')
         expect(incomingWebhooks.calls).to.have.length(1)
         const firstCall = incomingWebhooks.calls[0]
         expect(firstCall.params).to.deep.equal({parsed: 'body'})
@@ -164,8 +136,7 @@ describe('mocker: incoming webhooks', function () {
     let url
 
     beforeEach(function () {
-      url = 'http://reset.not.real'
-      incomingWebhooks.register(url)
+      url = 'https://hooks.slack.com/reset'
     })
 
     it('should reset call count', function (done) {


### PR DESCRIPTION
Incoming webhooks now intercept calls to `https://hooks.slack.com`.