### PR TITLE
Refactors RTM mocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,10 @@ It supports both GET and POST requests to all endpoints.
 
 - `addResponse`: `function(opts)` Queues a response payload that Slack Mock will use to respond upon
 receiving a request to a Web API endpoint. Endpoints without a custom response will return 200 `{ok: true}`.
-This method can be called multiple times per endpoint. Responses will be used in a FIFO order. Options are: 
+A `url` parameter will be added to all responses from the `https://slack.com/api/rtm.start` method if the body
+contains `ok: true`. 
+
+  This method can be called multiple times per endpoint. Responses will be used in a FIFO order. Options are: 
   - `url` (String, optional) Web API URL your app will be POSTing to.
   - `status` (Number, optional) The HTTP status code to reply with. Defaults to 200. 
   - `body` (Object, optional) The response body to reply with. Defaults to `{ok: true}`

--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ There is also a top level `reset` convenience method that will call reset on eac
 
 Slack mock will respond to all requests with a 200 OK unless a custom response has been queued. For web requests, a the default body will be `{ok: true}`.
 
+## RTM Conventions
+
+The RTM mocker creates a websocket server to intercept RTM websocket calls. This means unlike the other API mocks there are some truly asynchronous methods in the RTM mocker: `send` and `stopServer`. Both of these methods return promises that can be resolved or rejected.
+
+An RTM server will automatically be created when you call `https://slack.com/api/rtm.start` and will use the `token` parameter you pass as a unique identifier for this server. You will receive a URL in the response body for that RTM connection.
+
+You can start and stop the RTM server using the same access token. These methods provide a good way to test reconnection attempts by your bot as well as let you bootstrap and clean up after your tests. While you can start an RTM server explicitly in your tests, there is no need to do this if you call the `rtm.start` API method, as this will create a server for you.
+
 ## API
 
 ### `require('slack-mock')`: `function(config)`
@@ -308,12 +316,16 @@ bots or simulating bots that are connected to the same team. Returns an immediat
 - `send`: `function(message, client)` Sends a message from Slack to a connected client (bot).
 Returns an immediately resolved Promise for easy chaining.
 
-- `reset`: `function()` Clears the `rtm.calls` array and closes connections to all connected clients.
+- `reset`: `function()` Clears the `rtm.calls` array.
 
 - `calls`: `Array` An array of payloads received by the RTM API from your Slack app.
   - `message` The message that was received by the RTM API as an Object.
-  - `client` A reference to the websocket client that received the payload.
+  - `token` The token used in this message. This is the same token in your `message` payload. It can be used to call `startServer` and `stopServer`.
   - `rawMessage` The original String message received by the RTM API. Good for troubleshooting.
+  
+- `startServer`: `function(token)` Given the access token your bot will pass in messages, will start a web socket server. A web socket server will automatically be created for you when you call `https://slack.com/api/rtm.start` using the token you pass in the request.
+
+- `stopServer`: `function(token)` Given the access token your bot has passed in messages, will close the associated websocket server. This is handy for testing reconnection strategies by stopping the server, thus forcing a disconnect from your bot, then starting the server. It can also be used to clean up after a series of tests. 
 
 ---
 
@@ -350,6 +362,9 @@ The `web` object receives requests to the Slack Web API and responds with mocked
 
 This mock can be used both for the Web API and the OAuth endpoint (`https://slack.com/oauth/authorize`). 
 It supports both GET and POST requests to all endpoints.
+
+The `https://slack.com/api/rtm.start` call requires a `token` parameter either as a query parameter or in the POST body. This will be used
+to create an RTM server. See the [RTM docs](#instancertm-rtm) for more information.
 
 - `addResponse`: `function(opts)` Queues a response payload that Slack Mock will use to respond upon
 receiving a request to a Web API endpoint. Endpoints without a custom response will return 200 `{ok: true}`.

--- a/examples/slack-app/api.js
+++ b/examples/slack-app/api.js
@@ -48,8 +48,6 @@ function apiRequest (token, method, data, cb) {
     data.token = token
   }
 
-  console.log(method, token);
-
   request({
     method: 'GET',
     uri: `https://slack.com/api/${method}`,

--- a/examples/slack-app/api.js
+++ b/examples/slack-app/api.js
@@ -48,6 +48,8 @@ function apiRequest (token, method, data, cb) {
     data.token = token
   }
 
+  console.log(method, token);
+
   request({
     method: 'GET',
     uri: `https://slack.com/api/${method}`,

--- a/examples/test/single-team-bot.spec.js
+++ b/examples/test/single-team-bot.spec.js
@@ -5,6 +5,7 @@ const delay = require('delay')
 
 describe('single team bot', function () {
   let slackMock
+  const token = process.env.SLACK_TOKEN
 
   before(function () {
     slackMock = require('../../index').instance
@@ -33,11 +34,32 @@ describe('single team bot', function () {
   })
 
   it('should respond to hello with GO CUBS', function () {
-    return slackMock.rtm.send({type: 'message', channel: 'mockChannel', user: 'usr', text: 'hello'}, slackMock.rtm.clients[slackMock.rtm.clients.length - 1])
+    return slackMock.rtm.send({
+      token: token,
+      type: 'message',
+      channel: 'mockChannel',
+      user: 'usr',
+      text: 'hello'
+    })
       .then(delay(50))
       .then(() => {
         expect(slackMock.rtm.calls).to.have.length(1)
         expect(slackMock.rtm.calls[0].message.text).to.equal('GO CUBS')
+      })
+  })
+
+  it('should respond to howdy with GO TRIBE', function () {
+    return slackMock.rtm.send({
+      token: token,
+      type: 'message',
+      channel: 'mockChannel',
+      user: 'usr',
+      text: 'howdy'
+    })
+      .then(delay(50))
+      .then(() => {
+        expect(slackMock.rtm.calls).to.have.length(1)
+        expect(slackMock.rtm.calls[0].message.text).to.equal('GO TRIBE')
       })
   })
 })

--- a/examples/test/single-team-bot.spec.js
+++ b/examples/test/single-team-bot.spec.js
@@ -7,10 +7,11 @@ describe('single team bot', function () {
   let slackMock
 
   before(function () {
-    // wait for bot to get bootstrapped
-    this.timeout(30000)
-
     slackMock = require('../../index').instance
+  })
+
+  beforeEach(function () {
+    slackMock.reset()
 
     slackMock.web.addResponse({
       url: 'https://slack.com/api/rtm.start',
@@ -29,10 +30,6 @@ describe('single team bot', function () {
     require('../single-team-bot')
 
     return delay(100) // wait for bot to bootstrap and connect to rtm
-  })
-
-  beforeEach(function () {
-    slackMock.web.reset()
   })
 
   it('should respond to hello with GO CUBS', function () {

--- a/examples/test/single-team-bot.spec.js
+++ b/examples/test/single-team-bot.spec.js
@@ -9,11 +9,8 @@ describe('single team bot', function () {
 
   before(function () {
     slackMock = require('../../index').instance
-  })
 
-  beforeEach(function () {
-    slackMock.reset()
-
+    // required for bootstrap
     slackMock.web.addResponse({
       url: 'https://slack.com/api/rtm.start',
       status: 200,
@@ -28,9 +25,20 @@ describe('single team bot', function () {
       }
     })
 
+    // this bot can only be bootstrapped once
     require('../single-team-bot')
 
-    return delay(100) // wait for bot to bootstrap and connect to rtm
+    // wait for RTM flow to complete
+    return delay(50)
+  })
+
+  beforeEach(function () {
+    slackMock.reset()
+  })
+
+  after(function () {
+    // clean up server
+    return slackMock.rtm.stopServer(token)
   })
 
   it('should respond to hello with GO CUBS', function () {

--- a/examples/test/slack-app.spec.js
+++ b/examples/test/slack-app.spec.js
@@ -18,6 +18,10 @@ describe('slack-app', function () {
     require('../slack-app')
   })
 
+  after(function () {
+    return slackMock.rtm.stopServer(botToken)
+  })
+
   it('should start an rtm connection after the oauth flow', function (done) {
     slackMock.web.addResponse({
       url: 'https://slack.com/api/oauth.access',
@@ -59,7 +63,7 @@ describe('slack-app', function () {
       }
     }, (err) => {
       if (err) {
-        return console.log(err)
+        return done(err)
       }
 
       return delay(250) // wait for oauth flow to complete, rtm to be established

--- a/examples/test/slack-app.spec.js
+++ b/examples/test/slack-app.spec.js
@@ -7,6 +7,7 @@ const request = require('request')
 
 describe('slack-app', function () {
   let slackMock
+  const botToken = 'xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT'
 
   before(function () {
     // wait for bot to get bootstrapped
@@ -29,7 +30,7 @@ describe('slack-app', function () {
         team_id: 'XXXXXXXXXX',
         bot: {
           bot_user_id: 'UTTTTTTTTTTR',
-          bot_access_token: 'xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT'
+          bot_access_token: botToken
         }
       }
     })
@@ -63,7 +64,12 @@ describe('slack-app', function () {
 
       return delay(250) // wait for oauth flow to complete, rtm to be established
         .then(() => {
-          return slackMock.rtm.send({type: 'message', channel: 'mockChannel', user: 'usr', text: 'hello'}, slackMock.rtm.clients[slackMock.rtm.clients.length - 1])
+          return slackMock.rtm.send({
+            token: botToken,
+            type: 'message',
+            channel: 'mockChannel',
+            user: 'usr',
+            text: 'hello'})
         })
         .then(delay(20))
         .then(() => {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "scripts": {
     "pretest": "standard index.js src/*.js src/**/*.js test/*.js test/**/*.js examples/**/*.js --fix",
     "test": "istanbul cover --report lcov --dir ./coverage/ _mocha --recursive ./test/ --grep ./test/**/*.spec.js -- --colors --reporter spec",
-    "examples": "mocha --recursive ./examples/test/ ",
+    "examples": "SLACK_TOKEN='single-team-1' mocha --recursive ./examples/test/ ",
     "ci": "npm test && cat ./coverage/lcov.info | coveralls"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "express": "^4.14.0",
     "nock": "^9.0.2",
     "qs": "^6.3.0",
     "request": "^2.79.0",
@@ -23,7 +24,6 @@
     "chai": "^3.5.0",
     "coveralls": "^2.11.15",
     "delay": "^1.3.1",
-    "express": "^4.14.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "proxyquire": "^1.7.10",

--- a/src/index.js
+++ b/src/index.js
@@ -49,11 +49,11 @@ module.exports = function (config) {
       calls: outgoingWebhooks.calls
     },
     rtm: {
-      broadcast: rtm.broadcast,
       send: rtm.send,
       reset: rtm.reset,
       calls: rtm.calls,
-      clients: rtm.clients
+      startServer: rtm.startServer,
+      stopServer: rtm.stopServer
     },
     slashCommands: {
       addResponse: slashCommands.addResponse,

--- a/src/mocker/rtm.js
+++ b/src/mocker/rtm.js
@@ -23,8 +23,8 @@ rtm._.init = function (config) {
   baseUrl = `ws://localhost:${port}/`
 }
 
-rtm._.addToken = function(token) {
-  if(!wssServers.get(token)) {
+rtm._.addToken = function (token) {
+  if (!wssServers.get(token)) {
     const wss = new WebSocketServer({
       server: server,
       path: `/${token}`,
@@ -50,7 +50,6 @@ rtm.reset = function () {
 
   // in place reset
   rtm.calls.splice(0, rtm.calls.length)
-  return stopAllServers()
 }
 
 rtm.send = function (message) {
@@ -72,7 +71,7 @@ rtm.send = function (message) {
 }
 
 // sends the given message to the given client
-function sendToClient(message, client) {
+function sendToClient (message, client) {
   return new Promise((resolve, reject) => {
     try {
       client.send(JSON.stringify(message), (e) => {
@@ -90,9 +89,9 @@ function sendToClient(message, client) {
   })
 }
 
-rtm.stopServer = function(token) {
+rtm.stopServer = function (token) {
   return new Promise((resolve, reject) => {
-    const wss = wssServers.get('token')
+    const wss = wssServers.get(token)
     if (!wss) {
       return resolve()
     }
@@ -104,22 +103,13 @@ rtm.stopServer = function(token) {
       }
 
       logger.debug(`server ${token} closed`)
+      wssServers.delete(token)
       resolve()
     })
   })
 }
 
-function stopAllServers() {
-  const promises = []
-
-  for (let token of wssServers.keys()) {
-    promises.push(rtm.stopServer(token))
-  }
-
-  return Promise.all(promises)
-}
-
-rtm.startServer = function(token) {
+rtm.startServer = function (token) {
   rtm._.addToken(token)
 }
 
@@ -140,7 +130,7 @@ function recordMessage (client, message) {
 
   rtm.calls.push({
     rawMessage: message,
-    client: client,
+    token: parsedMessage ? parsedMessage.token : null,
     message: parsedMessage
   })
 }

--- a/src/mocker/web.js
+++ b/src/mocker/web.js
@@ -31,19 +31,21 @@ web.addResponse = function (opts) {
 
 function reply (path, requestBody) {
   const url = `https://slack.com${path.split('?')[0]}`
+  const params = utils.parseParams(path, requestBody)
 
   logger.debug(`intercepted web request: ${url}`)
 
   web.calls.push({
     url: url,
-    params: utils.parseParams(path, requestBody),
+    params: params,
     headers: this.req.headers
   })
 
   const response = customResponses.get('web', url)
   const body = response[1]
   if (/rtm\.start/.test(url) && body.ok) {
-    body.url = rtm._.url
+    const rtmUrl = rtm._.addToken(params.token)
+    body.url = rtmUrl
   }
 
   return response

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -52,11 +52,11 @@ describe('slack-mock', function () {
 
     rtmMock = {
       _: { init: sinon.stub() },
-      broadcast: sinon.stub(),
       send: sinon.stub(),
       reset: sinon.stub(),
       calls: [],
-      clients: []
+      stopServer: sinon.stub(),
+      startServer: sinon.stub()
     }
 
     slashCommandsMock = {
@@ -150,12 +150,12 @@ describe('slack-mock', function () {
     })
 
     it('should expose rtm api', function () {
-      expect(instance.rtm).to.have.keys(['broadcast', 'send', 'reset', 'calls', 'clients'])
-      expect(instance.rtm.broadcast, 'broadcast').to.equal(rtmMock.broadcast)
+      expect(instance.rtm).to.have.keys(['send', 'reset', 'calls', 'stopServer', 'startServer'])
       expect(instance.rtm.send, 'send').to.equal(rtmMock.send)
       expect(instance.rtm.reset, 'reset').to.equal(rtmMock.reset)
       expect(instance.rtm.calls, 'calls').to.equal(rtmMock.calls)
-      expect(instance.rtm.clients, 'clients').to.equal(rtmMock.clients)
+      expect(instance.rtm.stopServer, 'stopServer').to.equal(rtmMock.stopServer)
+      expect(instance.rtm.startServer, 'startServer').to.equal(rtmMock.startServer)
     })
 
     it('should expose slash commands api', function () {


### PR DESCRIPTION
Adds `startServer` and `stopServer` methods. These can be used for reconnection testing. `stopServer` can also be used in an `after` statement to clean up web socket servers that are no longer needed.

Refactors the way the server is established: instead of one shared web socket server, each access token will get a different web socket server. Servers can be started and stopped by passing a token, or will be automatically started for a token passed to the Web API `rtm.start` method.

closes #12
closes #14  
closes #15 
